### PR TITLE
Fix Streamlit Cloud deployment and UI improvements

### DIFF
--- a/drafty/app_standings.py
+++ b/drafty/app_standings.py
@@ -75,11 +75,11 @@ c1, c2, c3 = st.columns((0.50, 0.05, 0.50))
 
 c1.header("Standings by GW Bracket")
 gwbracket = c1.radio(
-    "Choose GW Bracket. **$50** Bracket Winner, **$25** for Runner-up",
+    "Choose GW Bracket. $50 Bracket Winner, $25 for Runner-up",
     ["Bracket 1", "Bracket 2", "Bracket 3"],
     captions=["GW 1 - 13", "GW 14 - 26", "GW 27 - 38"],
     horizontal=True,
-    index=2,
+    index=1,
 )
 
 if gwbracket == "Bracket 1":

--- a/poetry.lock
+++ b/poetry.lock
@@ -517,7 +517,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "python_version == \"3.12\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
+markers = "python_version < \"3.13\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.0.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a"},
     {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881"},
@@ -1286,7 +1286,10 @@ files = [
 ]
 
 [package.dependencies]
-numpy = {version = ">=1.26.0", markers = "python_version >= \"3.12\""}
+numpy = [
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
 tzdata = ">=2022.7"
@@ -2391,5 +2394,5 @@ dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12,<3.14"
-content-hash = "431221bbd8c297f84cfebbac8d6919459836d933028096dae7c96745a9b43a91"
+python-versions = ">=3.11,<3.14"
+content-hash = "3e260e041538c91cad5a53e6c3d8a2fba6e283623406b73f2c5842277c373188"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.12,<3.14"
+python = ">=3.11,<3.14"
 duckdb = "^1.0.0"
 streamlit = "^1.37.0"
 streamlit-extras = "^0.4.3"


### PR DESCRIPTION
## Summary
- Fix Python version constraint to allow 3.11 (required by Streamlit Cloud)
- Fix invalid escape sequence warning in app_standings.py
- Change default bracket selection to Bracket 2
- Fix radio label markdown formatting issue

## Test plan
- [ ] Verify Streamlit Cloud deployment succeeds
- [ ] Verify standings page loads with Bracket 2 selected by default
- [ ] Verify radio button label displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)